### PR TITLE
Update Constants.php

### DIFF
--- a/src/Config/Constants.php
+++ b/src/Config/Constants.php
@@ -29,10 +29,10 @@ define('__EXT__', '.php');
 | always be used to set the mode correctly.
 |
 */
-define('FILE_READ_MODE', 0644);
-define('FILE_WRITE_MODE', 0666);
-define('DIR_READ_MODE', 0755);
-define('DIR_WRITE_MODE', 0755);
+defined('FILE_READ_MODE') || define('FILE_READ_MODE', 0644);
+defined('FILE_WRITE_MODE') || define('FILE_WRITE_MODE', 0666);
+defined('DIR_READ_MODE') || define('DIR_READ_MODE', 0755);
+defined('DIR_WRITE_MODE') || define('DIR_WRITE_MODE', 0755);
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
Fix bug when integrating o2system kernel with Codeigniter Framework. The problem occurs because the Codeigniter framework already has these definitions on their constants configuration at "application/config/constants.php".